### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=RDM6300
+version=0.0.0
+author=Fabian Grebe
+maintainer=Fabian Grebe
+sentence=Arduino Library for RFID module RDM6300 
+paragraph=
+category=Device Control
+url=https://github.com/fixItFab/RDM6300
+architectures=*
+includes=RDM6300.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the `src` subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata